### PR TITLE
Fix signing for newest geth lib / EIP155

### DIFF
--- a/txsign/txsign.go
+++ b/txsign/txsign.go
@@ -92,15 +92,19 @@ func main() {
 	// signature, _ := crypto.Sign(transaction.SigHash().Bytes(), key)
 	// signed, _ := tx.WithSignature(signature)
 
-	tx := types.NewTransaction(nonce, to_addr, amount_wei, gas_limit,
-		gas_price, nil)
+	tx := types.NewTransaction(nonce, to_addr, amount_wei, gas_limit, gas_price, nil)
 
-	signature, err := am.Sign(from_addr, tx.SigHash().Bytes())
+	signer := types.HomesteadSigner{}
+
+	signature, err := am.Sign(from_addr, tx.SigHash(signer).Bytes())
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	signed_tx, err := tx.WithSignature(signature)
+	//fmt.Println(signature)
+	//fmt.Println(tx)
+
+	signed_tx, err := tx.WithSignature(signer, signature)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Geth library added different types of signers because of EIP155 replay protection, this fixes it so that the lib compiles again using the Homestead signer